### PR TITLE
Change message parsing to be closer to RFC1459

### DIFF
--- a/message.go
+++ b/message.go
@@ -152,12 +152,8 @@ func (p *Prefix) writeTo(buffer *bytes.Buffer) {
 //    <crlf>     ::= CR LF
 type Message struct {
 	*Prefix
-	Command  string
-	Params   []string
-	Trailing string
-
-	// When set to true, the trailing prefix (:) will be added even if the trailing message is empty.
-	EmptyTrailing bool
+	Command string
+	Params  []string
 }
 
 // ParseMessage takes a string and attempts to create a Message struct.
@@ -169,67 +165,50 @@ func ParseMessage(raw string) (m *Message) {
 		return nil
 	}
 
-	i, j := 0, 0
-
 	m = new(Message)
 
 	if raw[0] == prefix {
 
-		// Prefix ends with a space.
-		i = indexByte(raw, space)
-
-		// Prefix string must not be empty if the indicator is present.
-		if i < 2 {
+		// Split the string on space, skipping the first character
+		split := strings.SplitN(raw[1:], " ", 2)
+		if len(split) < 2 || len(split[0]) < 1 {
 			return nil
 		}
 
-		m.Prefix = ParsePrefix(raw[1:i])
+		// Parse the first part of the split as the prefix
+		m.Prefix = ParsePrefix(split[0])
 
-		// Skip space at the end of the prefix
-		i++
+		// We can continue to parse the remainder of the message
+		raw = split[1]
+
 	}
 
-	// Find end of command
-	j = i + indexByte(raw[i:], space)
+	// We split out trailing now. This way, using Fields to split the rest of
+	// the parameters will remove duplicate spaces
+	split := strings.SplitN(raw, " :", 2)
 
-	// Extract command
-	if j > i {
-		m.Command = raw[i:j]
-	} else {
-		m.Command = raw[i:]
+	// Because params can be delimited by one or more spaces, we have to use
+	// strings.FieldsFunc, rather than strings.Split
+	m.Params = strings.FieldsFunc(split[0], func(r rune) bool {
+		return r == ' '
+	})
 
-		// We're done here!
-		return m
+	// The first param is the command, so we bail if we can't find it
+	if len(m.Params) < 1 {
+		return nil
 	}
 
-	// Skip space after command
-	j++
+	m.Command = m.Params[0]
+	m.Params = m.Params[1:]
 
-	// Find prefix for trailer
-	i = indexByte(raw[j:], prefix)
-
-	if i < 0 {
-
-		// There is no trailing argument!
-		m.Params = strings.Split(raw[j:], string(space))
-
-		// We're done here!
-		return m
+	// Append the trailing argument onto the params if we had one
+	if len(split) == 2 {
+		m.Params = append(m.Params, split[1])
 	}
 
-	// Compensate for index on substring
-	i = i + j
-
-	// Check if we need to parse arguments.
-	if i > j {
-		m.Params = strings.Split(raw[j:i-1], string(space))
-	}
-
-	m.Trailing = raw[i+1:]
-
-	// We need to re-encode the trailing argument even if it was empty.
-	if len(m.Trailing) <= 0 {
-		m.EmptyTrailing = true
+	// If there were no params, set it to nil to be consistent
+	if len(m.Params) == 0 {
+		m.Params = nil
 	}
 
 	return m
@@ -246,14 +225,12 @@ func (m *Message) Len() (length int) {
 	length = length + len(m.Command)
 
 	if len(m.Params) > 0 {
-		length = length + len(m.Params)
+		// len(m.Params) is the number of spaces. We add one for the : in the
+		// trailing argument.
+		length = length + len(m.Params) + 1
 		for _, param := range m.Params {
 			length = length + len(param)
 		}
-	}
-
-	if len(m.Trailing) > 0 || m.EmptyTrailing {
-		length = length + len(m.Trailing) + 2 // Include prefix and space
 	}
 
 	return
@@ -280,14 +257,13 @@ func (m *Message) Bytes() []byte {
 
 	// Space separated list of arguments
 	if len(m.Params) > 0 {
-		buffer.WriteByte(space)
-		buffer.WriteString(strings.Join(m.Params, string(space)))
-	}
-
-	if len(m.Trailing) > 0 || m.EmptyTrailing {
+		if len(m.Params) > 1 {
+			buffer.WriteByte(space)
+			buffer.WriteString(strings.Join(m.Params[:len(m.Params)-1], string(space)))
+		}
 		buffer.WriteByte(space)
 		buffer.WriteByte(prefix)
-		buffer.WriteString(m.Trailing)
+		buffer.WriteString(m.Params[len(m.Params)-1])
 	}
 
 	// We need the limit the buffer length.

--- a/message.go
+++ b/message.go
@@ -215,6 +215,18 @@ func ParseMessage(raw string) (m *Message) {
 
 }
 
+//Trailing returns the last param of a message, or an empty string if there
+// were no params.
+func (m *Message) Trailing() string {
+
+	if len(m.Params) == 0 {
+		return ""
+	}
+
+	return m.Params[len(m.Params)-1]
+
+}
+
 // Len calculates the length of the string representation of this message.
 func (m *Message) Len() (length int) {
 

--- a/message_test.go
+++ b/message_test.go
@@ -10,11 +10,12 @@ import (
 )
 
 var messageTests = [...]*struct {
-	parsed     *Message
-	rawMessage string
-	rawPrefix  string
-	hostmask   bool // Is it very clear that the prefix is a hostname?
-	server     bool // Is the prefix a servername?
+	parsed            *Message
+	normalizedMessage string
+	rawMessage        string
+	rawPrefix         string
+	hostmask          bool // Is it very clear that the prefix is a hostname?
+	server            bool // Is the prefix a servername?
 }{
 	{
 		parsed: &Message{
@@ -23,8 +24,8 @@ var messageTests = [...]*struct {
 				User: "kalt",
 				Host: "millennium.stealth.net",
 			},
-			Command:  "QUIT",
-			Trailing: "Gone to have lunch",
+			Command: "QUIT",
+			Params:  []string{"Gone to have lunch"},
 		},
 		rawMessage: ":syrk!kalt@millennium.stealth.net QUIT :Gone to have lunch",
 		rawPrefix:  "syrk!kalt@millennium.stealth.net",
@@ -35,9 +36,8 @@ var messageTests = [...]*struct {
 			Prefix: &Prefix{
 				Name: "Trillian",
 			},
-			Command:  "SQUIT",
-			Params:   []string{"cm22.eng.umd.edu"},
-			Trailing: "Server out of control",
+			Command: "SQUIT",
+			Params:  []string{"cm22.eng.umd.edu", "Server out of control"},
 		},
 		rawMessage: ":Trillian SQUIT cm22.eng.umd.edu :Server out of control",
 		rawPrefix:  "Trillian",
@@ -53,9 +53,10 @@ var messageTests = [...]*struct {
 			Command: "JOIN",
 			Params:  []string{"#Twilight_zone"},
 		},
-		rawMessage: ":WiZ!jto@tolsun.oulu.fi JOIN #Twilight_zone",
-		rawPrefix:  "WiZ!jto@tolsun.oulu.fi",
-		hostmask:   true,
+		normalizedMessage: ":WiZ!jto@tolsun.oulu.fi JOIN :#Twilight_zone",
+		rawMessage:        ":WiZ!jto@tolsun.oulu.fi JOIN #Twilight_zone",
+		rawPrefix:         "WiZ!jto@tolsun.oulu.fi",
+		hostmask:          true,
 	},
 	{
 		parsed: &Message{
@@ -64,9 +65,8 @@ var messageTests = [...]*struct {
 				User: "jto",
 				Host: "tolsun.oulu.fi",
 			},
-			Command:  "PART",
-			Params:   []string{"#playzone"},
-			Trailing: "I lost",
+			Command: "PART",
+			Params:  []string{"#playzone", "I lost"},
 		},
 		rawMessage: ":WiZ!jto@tolsun.oulu.fi PART #playzone :I lost",
 		rawPrefix:  "WiZ!jto@tolsun.oulu.fi",
@@ -82,22 +82,23 @@ var messageTests = [...]*struct {
 			Command: "MODE",
 			Params:  []string{"#eu-opers", "-l"},
 		},
-		rawMessage: ":WiZ!jto@tolsun.oulu.fi MODE #eu-opers -l",
-		rawPrefix:  "WiZ!jto@tolsun.oulu.fi",
-		hostmask:   true,
+		normalizedMessage: ":WiZ!jto@tolsun.oulu.fi MODE #eu-opers :-l",
+		rawMessage:        ":WiZ!jto@tolsun.oulu.fi MODE #eu-opers -l",
+		rawPrefix:         "WiZ!jto@tolsun.oulu.fi",
+		hostmask:          true,
 	},
 	{
 		parsed: &Message{
 			Command: "MODE",
 			Params:  []string{"&oulu", "+b", "*!*@*.edu", "+e", "*!*@*.bu.edu"},
 		},
-		rawMessage: "MODE &oulu +b *!*@*.edu +e *!*@*.bu.edu",
+		normalizedMessage: "MODE &oulu +b *!*@*.edu +e :*!*@*.bu.edu",
+		rawMessage:        "MODE &oulu +b *!*@*.edu +e *!*@*.bu.edu",
 	},
 	{
 		parsed: &Message{
-			Command:  "PRIVMSG",
-			Params:   []string{"#channel"},
-			Trailing: "Message with :colons!",
+			Command: "PRIVMSG",
+			Params:  []string{"#channel", "Message with :colons!"},
 		},
 		rawMessage: "PRIVMSG #channel :Message with :colons!",
 	},
@@ -106,9 +107,8 @@ var messageTests = [...]*struct {
 			Prefix: &Prefix{
 				Name: "irc.vives.lan",
 			},
-			Command:  "251",
-			Params:   []string{"test"},
-			Trailing: "There are 2 users and 0 services on 1 servers",
+			Command: "251",
+			Params:  []string{"test", "There are 2 users and 0 services on 1 servers"},
 		},
 		rawMessage: ":irc.vives.lan 251 test :There are 2 users and 0 services on 1 servers",
 		rawPrefix:  "irc.vives.lan",
@@ -119,9 +119,8 @@ var messageTests = [...]*struct {
 			Prefix: &Prefix{
 				Name: "irc.vives.lan",
 			},
-			Command:  "376",
-			Params:   []string{"test"},
-			Trailing: "End of MOTD command",
+			Command: "376",
+			Params:  []string{"test", "End of MOTD command"},
 		},
 		rawMessage: ":irc.vives.lan 376 test :End of MOTD command",
 		rawPrefix:  "irc.vives.lan",
@@ -132,9 +131,8 @@ var messageTests = [...]*struct {
 			Prefix: &Prefix{
 				Name: "irc.vives.lan",
 			},
-			Command:  "250",
-			Params:   []string{"test"},
-			Trailing: "Highest connection count: 1 (1 connections received)",
+			Command: "250",
+			Params:  []string{"test", "Highest connection count: 1 (1 connections received)"},
 		},
 		rawMessage: ":irc.vives.lan 250 test :Highest connection count: 1 (1 connections received)",
 		rawPrefix:  "irc.vives.lan",
@@ -147,9 +145,8 @@ var messageTests = [...]*struct {
 				User: "~sorcix",
 				Host: "sorcix.users.quakenet.org",
 			},
-			Command:  "PRIVMSG",
-			Params:   []string{"#viveslan"},
-			Trailing: "\001ACTION is testing CTCP messages!\001",
+			Command: "PRIVMSG",
+			Params:  []string{"#viveslan", "\001ACTION is testing CTCP messages!\001"},
 		},
 		rawMessage: ":sorcix!~sorcix@sorcix.users.quakenet.org PRIVMSG #viveslan :\001ACTION is testing CTCP messages!\001",
 		rawPrefix:  "sorcix!~sorcix@sorcix.users.quakenet.org",
@@ -162,9 +159,8 @@ var messageTests = [...]*struct {
 				User: "~sorcix",
 				Host: "sorcix.users.quakenet.org",
 			},
-			Command:  "NOTICE",
-			Params:   []string{"midnightfox"},
-			Trailing: "\001PONG 1234567890\001",
+			Command: "NOTICE",
+			Params:  []string{"midnightfox", "\001PONG 1234567890\001"},
 		},
 		rawMessage: ":sorcix!~sorcix@sorcix.users.quakenet.org NOTICE midnightfox :\001PONG 1234567890\001",
 		rawPrefix:  "sorcix!~sorcix@sorcix.users.quakenet.org",
@@ -189,8 +185,8 @@ var messageTests = [...]*struct {
 				Name: "a",
 				User: "b",
 			},
-			Command:  "PRIVMSG",
-			Trailing: "message",
+			Command: "PRIVMSG",
+			Params:  []string{"message"},
 		},
 		rawMessage: ":a!b PRIVMSG :message",
 		rawPrefix:  "a!b",
@@ -201,8 +197,8 @@ var messageTests = [...]*struct {
 				Name: "a",
 				Host: "c",
 			},
-			Command:  "NOTICE",
-			Trailing: ":::Hey!",
+			Command: "NOTICE",
+			Params:  []string{":::Hey!"},
 		},
 		rawMessage: ":a@c NOTICE ::::Hey!",
 		rawPrefix:  "a@c",
@@ -212,20 +208,19 @@ var messageTests = [...]*struct {
 			Prefix: &Prefix{
 				Name: "nick",
 			},
-			Command:  "PRIVMSG",
-			Params:   []string{"$@"},
-			Trailing: "This message contains a\ttab!",
+			Command: "PRIVMSG",
+			Params:  []string{"$@", "This message contains a\ttab!"},
 		},
 		rawMessage: ":nick PRIVMSG $@ :This message contains a\ttab!",
 		rawPrefix:  "nick",
 	},
 	{
 		parsed: &Message{
-			Command:  "TEST",
-			Params:   []string{"$@", "", "param"},
-			Trailing: "Trailing",
+			Command: "TEST",
+			Params:  []string{"$@", "param", "Trailing"},
 		},
-		rawMessage: "TEST $@  param :Trailing",
+		normalizedMessage: "TEST $@ param :Trailing",
+		rawMessage:        "TEST $@  param :Trailing",
 	},
 	{
 		rawMessage: ": PRIVMSG test :Invalid message with empty prefix.",
@@ -236,20 +231,22 @@ var messageTests = [...]*struct {
 		rawPrefix:  " ",
 	},
 	{
-		parsed: &Message{
-			Command:  "TOPIC",
-			Params:   []string{"#foo"},
-			Trailing: "",
-		},
-		rawMessage: "TOPIC #foo",
-		rawPrefix:  "",
+		rawMessage: ":prefix ",
+		rawPrefix:  "prefix",
 	},
 	{
 		parsed: &Message{
-			Command:       "TOPIC",
-			Params:        []string{"#foo"},
-			Trailing:      "",
-			EmptyTrailing: true,
+			Command: "TOPIC",
+			Params:  []string{"#foo"},
+		},
+		normalizedMessage: "TOPIC :#foo",
+		rawMessage:        "TOPIC #foo",
+		rawPrefix:         "",
+	},
+	{
+		parsed: &Message{
+			Command: "TOPIC",
+			Params:  []string{"#foo", ""},
 		},
 		rawMessage: "TOPIC #foo :",
 		rawPrefix:  "",
@@ -261,13 +258,15 @@ var messageTests = [...]*struct {
 				User: "user",
 				Host: "example.org",
 			},
-			Command:  "PRIVMSG",
-			Params:   []string{"#test"},
-			Trailing: "Message with spaces at the end!  ",
+			Command: "PRIVMSG",
+			Params:  []string{"#test", "Message with spaces at the end!  "},
 		},
 		rawMessage: ":name!user@example.org PRIVMSG #test :Message with spaces at the end!  ",
 		rawPrefix:  "name!user@example.org",
 		hostmask:   true,
+	},
+	{
+		rawMessage: "",
 	},
 }
 
@@ -390,10 +389,15 @@ func TestMessage_String(t *testing.T) {
 		s = test.parsed.String()
 
 		// Result should be the same as the value in rawMessage.
-		if s != test.rawMessage {
+		msg := test.rawMessage
+		if test.normalizedMessage != "" {
+			msg = test.normalizedMessage
+		}
+
+		if s != msg {
 			t.Errorf("Failed to stringify message %d:", i)
 			t.Logf("Output: %s", s)
-			t.Logf("Expected: %s", test.rawMessage)
+			t.Logf("Expected: %s", msg)
 		}
 	}
 }
@@ -411,10 +415,15 @@ func TestMessage_Len(t *testing.T) {
 		l = test.parsed.Len()
 
 		// Result should be the same as the value in rawMessage.
-		if l != len(test.rawMessage) {
+		msg := test.rawMessage
+		if test.normalizedMessage != "" {
+			msg = test.normalizedMessage
+		}
+
+		if l != len(msg) {
 			t.Errorf("Failed to calculate message length %d:", i)
 			t.Logf("Output: %d", l)
-			t.Logf("Expected: %d", len(test.rawMessage))
+			t.Logf("Expected: %d", len(msg))
 		}
 	}
 }
@@ -458,7 +467,12 @@ func TestMessageDecodeEncode(t *testing.T) {
 		s = p.String()
 
 		// Result struct should be the same as the original.
-		if s != test.rawMessage {
+		msg := test.rawMessage
+		if test.normalizedMessage != "" {
+			msg = test.normalizedMessage
+		}
+
+		if s != msg {
 			t.Errorf("Message %d failed decode-encode sequence!", i)
 		}
 	}

--- a/stream_test.go
+++ b/stream_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 )
 
+var normalizedStream = "PING :port80a.se.quakenet.org\r\n:port80a.se.quakenet.org PONG port80a.se.quakenet.org :port80a.se.quakenet.org\r\nPING :chat.freenode.net\r\n:wilhelm.freenode.net PONG wilhelm.freenode.net :chat.freenode.net\r\n"
 var stream = "PING port80a.se.quakenet.org\r\n:port80a.se.quakenet.org PONG port80a.se.quakenet.org :port80a.se.quakenet.org\r\nPING chat.freenode.net\r\n:wilhelm.freenode.net PONG wilhelm.freenode.net :chat.freenode.net\r\n"
 
 var result = [...]*Message{
@@ -23,9 +24,8 @@ var result = [...]*Message{
 		Prefix: &Prefix{
 			Name: "port80a.se.quakenet.org",
 		},
-		Command:  PONG,
-		Params:   []string{"port80a.se.quakenet.org"},
-		Trailing: "port80a.se.quakenet.org",
+		Command: PONG,
+		Params:  []string{"port80a.se.quakenet.org", "port80a.se.quakenet.org"},
 	},
 	{
 		Command: PING,
@@ -35,9 +35,8 @@ var result = [...]*Message{
 		Prefix: &Prefix{
 			Name: "wilhelm.freenode.net",
 		},
-		Command:  PONG,
-		Params:   []string{"wilhelm.freenode.net"},
-		Trailing: "chat.freenode.net",
+		Command: PONG,
+		Params:  []string{"wilhelm.freenode.net", "chat.freenode.net"},
 	},
 }
 
@@ -72,7 +71,7 @@ func TestEncoder_Encode(t *testing.T) {
 		}
 	}
 
-	if buffer.String() != stream {
+	if buffer.String() != normalizedStream {
 		t.Fatalf("Encoded stream looks wrong!")
 	}
 


### PR DESCRIPTION
This moves the trailing parameter to the Params slice as well as removes Trailing and EmptyTrailing.

I ended up completely rewriting the ParseMessage to use strings.Split and strings.Fields. This also makes it impossible to have empty params (as that is not allowed in the RFC1459) and makes it possible to have multiple spaces between params (because for whatever reason space is defined as one or more spaces).

This is a breaking change, but it has been discussed in #8.

I did not include `func (e *Message) Trailing() string` and may have missed a few things, especially in terms of code style, however this is the first step towards this change.