### PR TITLE
Allow travis to fail for go 1.0 and 1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,3 +8,7 @@ go:
    - tip
 script:
    - go test -v
+matrix:
+  allow_failures:
+      - go: 1.0
+      - go: 1.1


### PR DESCRIPTION
I'm not sure if we want them to fail, but as master currently fails, I think this is reasonable.