### PR TITLE
Ensure commands are uppercase to avoid compairson errors

### DIFF
--- a/message.go
+++ b/message.go
@@ -194,9 +194,9 @@ func ParseMessage(raw string) (m *Message) {
 
 	// Extract command
 	if j > i {
-		m.Command = raw[i:j]
+		m.Command = strings.ToUpper(raw[i:j])
 	} else {
-		m.Command = raw[i:]
+		m.Command = strings.ToUpper(raw[i:])
 
 		// We're done here!
 		return m


### PR DESCRIPTION
Had some minor logic errors due to case sensitive checks. I had them outside the lib but it seems to make sense to move them into parse.