### PR TITLE
Move indexByte to an internal package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,3 @@ script:
 matrix:
   allow_failures:
     - go: 1.0
-    - go: 1.1

--- a/ctcp/ctcp.go
+++ b/ctcp/ctcp.go
@@ -11,8 +11,9 @@ package ctcp
 import (
 	"fmt"
 	"runtime"
-	"strings"
 	"time"
+
+	"gopkg.in/sorcix/irc.v2/internal"
 )
 
 // Various constants used for formatting CTCP messages.
@@ -53,7 +54,7 @@ func Decode(text string) (tag, message string, ok bool) {
 		return empty, empty, false
 	}
 
-	s := strings.IndexByte(text, space)
+	s := internal.IndexByte(text, space)
 
 	if s < 0 {
 
@@ -81,11 +82,10 @@ func Encode(tag, message string) (text string) {
 	case len(message) > 0:
 		return string(delimiter) + tag + string(space) + message + string(delimiter)
 
-	// Tagged data without a message
-	default:
-		return string(delimiter) + tag + string(delimiter)
-
 	}
+
+	// Tagged data without a message
+	return string(delimiter) + tag + string(delimiter)
 }
 
 // Action is a shortcut for Encode(ctcp.ACTION, message).

--- a/internal/strings.go
+++ b/internal/strings.go
@@ -6,12 +6,14 @@
 
 // Documented in strings_legacy.go
 
-package irc
+package internal
 
 import (
 	"strings"
 )
 
-func indexByte(s string, c byte) int {
+// IndexByte is a compatibility function so strings.IndexByte can be used in
+// older versions of go.
+func IndexByte(s string, c byte) int {
 	return strings.IndexByte(s, c)
 }

--- a/internal/strings_legacy.go
+++ b/internal/strings_legacy.go
@@ -9,10 +9,10 @@
 //
 // This code may be removed when Wheezy is no longer supported.
 
-package irc
+package internal
 
-// indexByte implements strings.IndexByte for Go versions < 1.2.
-func indexByte(s string, c byte) int {
+// IndexByte implements strings.IndexByte for Go versions < 1.2.
+func IndexByte(s string, c byte) int {
 	for i := range s {
 		if s[i] == c {
 			return i

--- a/message.go
+++ b/message.go
@@ -7,6 +7,8 @@ package irc
 import (
 	"bytes"
 	"strings"
+
+	"gopkg.in/sorcix/irc.v2/internal"
 )
 
 // Various constants used for formatting IRC messages.
@@ -52,8 +54,8 @@ func ParsePrefix(raw string) (p *Prefix) {
 
 	p = new(Prefix)
 
-	user := indexByte(raw, prefixUser)
-	host := indexByte(raw, prefixHost)
+	user := internal.IndexByte(raw, prefixUser)
+	host := internal.IndexByte(raw, prefixHost)
 
 	switch {
 
@@ -118,7 +120,7 @@ func (p *Prefix) IsHostmask() bool {
 
 // IsServer returns true if this prefix looks like a server name.
 func (p *Prefix) IsServer() bool {
-	return len(p.User) <= 0 && len(p.Host) <= 0 // && indexByte(p.Name, '.') > 0
+	return len(p.User) <= 0 && len(p.Host) <= 0 // && internal.IndexByte(p.Name, '.') > 0
 }
 
 // writeTo is an utility function to write the prefix to the bytes.Buffer in Message.String().
@@ -179,7 +181,7 @@ func ParseMessage(raw string) (m *Message) {
 	if raw[0] == prefix {
 
 		// Prefix ends with a space.
-		i = indexByte(raw, space)
+		i = internal.IndexByte(raw, space)
 
 		// Prefix string must not be empty if the indicator is present.
 		if i < 2 {
@@ -193,7 +195,7 @@ func ParseMessage(raw string) (m *Message) {
 	}
 
 	// Find end of command
-	j = i + indexByte(raw[i:], space)
+	j = i + internal.IndexByte(raw[i:], space)
 
 	// Extract command
 	if j > i {
@@ -209,7 +211,7 @@ func ParseMessage(raw string) (m *Message) {
 	j++
 
 	// Find prefix for trailer
-	i = indexByte(raw[j:], prefix)
+	i = internal.IndexByte(raw[j:], prefix)
 
 	if i < 0 || raw[j+i-1] != space {
 


### PR DESCRIPTION
This allows both the ctcp package and the irc package to share the code, which
should allow the build to succeed for 1.1 again.

Internal packages are enforced from version 1.5 up, but should still work with lower versions.

This also partially fixes #21, but is complicated by the fact that go 1.0 doesn't have `b.ReportAllocs()` or `-test.benchmem` or `-benchmem`.