### PR TITLE
Add Param method to Message type

### DIFF
--- a/message.go
+++ b/message.go
@@ -158,6 +158,15 @@ type Message struct {
 	Params  []string
 }
 
+// Param returns the i'th parameter.
+// Returns the empty string if the requested parameter does not exist.
+func (m *Message) Param(i int) string {
+	if i < 0 || i >= len(m.Params) {
+		return ""
+	}
+	return m.Params[i]
+}
+
 // Trailing returns the last parameter.
 // Returns the empty string if there are no parameters.
 func (m *Message) Trailing() string {

--- a/message.go
+++ b/message.go
@@ -158,6 +158,8 @@ type Message struct {
 	Params  []string
 }
 
+// Trailing returns the last parameter.
+// Returns the empty string if there are no parameters.
 func (m *Message) Trailing() string {
 	if len(m.Params) > 0 {
 		return m.Params[len(m.Params)-1]

--- a/message_test.go
+++ b/message_test.go
@@ -438,6 +438,30 @@ func TestMessage_Len(t *testing.T) {
 	}
 }
 
+func TestMessage_Param(t *testing.T) {
+	msg := &Message{
+		Params: []string{"foo", "bar", "baz"},
+	}
+
+	tests := [...]struct {
+		i     int
+		value string
+	}{
+		{i: 0, value: "foo"},
+		{i: 2, value: "baz"},
+		{i: 99, value: ""},
+		{i: -1, value: ""},
+	}
+	for i, test := range tests {
+		p := msg.Param(test.i)
+		if p != test.value {
+			t.Errorf("Failed to get parameter: %d", i)
+			t.Logf("Output: %s", p)
+			t.Logf("Expected: %s", test.value)
+		}
+	}
+}
+
 func TestParseMessage(t *testing.T) {
 	var p *Message
 


### PR DESCRIPTION
I have a lot of code that looks like this

``` go
if len(m.Params) > 1 && m.Params[1] == "ACK") || len(m.Params) == 1 && m.Params[0] == "+" {
    // do something
}
```

With the added method, this becomes.

``` go
if m.Param(1) == "ACK" || m.Param(0) == "+" {
    // do something
}
```

This is analogous to the [flag.Arg(i int)](https://golang.org/pkg/flag/#Arg) helper.