### PR TITLE
fix bug where RPL_BOUNCE conflicted with RPL_ISUPPORT

### DIFF
--- a/constants.go
+++ b/constants.go
@@ -98,7 +98,7 @@ const (
 	RPL_YOURHOST          = "002"
 	RPL_CREATED           = "003"
 	RPL_MYINFO            = "004"
-	RPL_BOUNCE            = "005"
+	RPL_BOUNCE            = "010"
 	RPL_ISUPPORT          = "005"
 	RPL_USERHOST          = "302"
 	RPL_ISON              = "303"


### PR DESCRIPTION
in practice RPL_BOUNCE has been moved to 010.

Feel free to close, as it's technically not accurate to the earlier comment on line 95 of being extracted from RFC 2812.